### PR TITLE
Add demo data generator and replay scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,37 @@
-# firesight-prototype
+# FireSight Prototype
+
+This repository contains a simple prototype for the FireSight user interface. It now also includes scripts for generating demo datasets used during development and testing.
+
+## Demo Data Scripts
+
+The `scripts` directory contains two helper utilities:
+
+- `generate_demo_dataset.py` – creates a 24‑hour CSV file with simulated sensor readings and a fire ignition event around noon.
+- `replay_fire_scenario.py` – prints dataset rows to the console in sequence so the scenario can be replayed quickly for demos.
+
+### Dataset format
+
+The generated CSV has the following columns:
+
+| column | description |
+| --- | --- |
+| `timestamp` | ISO‑8601 timestamp for each minute of the day |
+| `temperature_c` | temperature in Celsius |
+| `humidity_pct` | relative humidity percentage |
+| `co2_ppm` | CO₂ concentration in ppm |
+| `smoke` | `0` or `1` to indicate smoke detection |
+| `flame` | `0` or `1` to indicate flame detection |
+
+The ignition event increases temperature and CO₂ while setting both `smoke` and `flame` to `1` for approximately 15 minutes.
+
+To create the dataset run:
+
+```bash
+python3 scripts/generate_demo_dataset.py demo_dataset.csv
+```
+
+Then replay it with:
+
+```bash
+python3 scripts/replay_fire_scenario.py demo_dataset.csv
+```

--- a/scripts/generate_demo_dataset.py
+++ b/scripts/generate_demo_dataset.py
@@ -1,0 +1,66 @@
+import csv
+import random
+from datetime import datetime, timedelta
+import argparse
+
+
+def generate_dataset(output_path: str, start_time: datetime, minutes: int = 1440):
+    """Generate a simulated multi-sensor dataset with a fire ignition event."""
+    ignition_start = start_time + timedelta(hours=12)
+    ignition_end = ignition_start + timedelta(minutes=15)
+
+    fieldnames = [
+        "timestamp",
+        "temperature_c",
+        "humidity_pct",
+        "co2_ppm",
+        "smoke",
+        "flame"
+    ]
+
+    with open(output_path, "w", newline="") as csvfile:
+        writer = csv.DictWriter(csvfile, fieldnames=fieldnames)
+        writer.writeheader()
+
+        current_time = start_time
+        for _ in range(minutes):
+            row = {
+                "timestamp": current_time.isoformat(),
+                "temperature_c": round(random.uniform(18, 25), 2),
+                "humidity_pct": round(random.uniform(35, 55), 2),
+                "co2_ppm": round(random.uniform(400, 600), 2),
+                "smoke": 0,
+                "flame": 0,
+            }
+
+            if ignition_start <= current_time <= ignition_end:
+                # escalate sensor readings to simulate fire
+                progress = (current_time - ignition_start).total_seconds() / (
+                    ignition_end - ignition_start
+                ).total_seconds()
+                row["temperature_c"] = round(25 + 75 * progress, 2)
+                row["humidity_pct"] = round(30 - 20 * progress, 2)
+                row["co2_ppm"] = round(600 + 500 * progress, 2)
+                row["smoke"] = 1
+                row["flame"] = 1 if progress > 0.3 else 0
+
+            writer.writerow(row)
+            current_time += timedelta(minutes=1)
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Generate a demo FireSight dataset")
+    parser.add_argument(
+        "output",
+        help="Path to output CSV file",
+        default="demo_dataset.csv",
+        nargs="?",
+    )
+    args = parser.parse_args()
+    start = datetime(2025, 5, 11)
+    generate_dataset(args.output, start)
+    print(f"Dataset written to {args.output}")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/replay_fire_scenario.py
+++ b/scripts/replay_fire_scenario.py
@@ -1,0 +1,34 @@
+import csv
+import argparse
+import time
+from datetime import datetime
+
+
+def replay_dataset(path: str, speed: float = 600.0):
+    """Replay dataset rows to stdout at accelerated speed.
+
+    Each row represents a minute. The speed factor represents how many
+    dataset minutes pass per real second. Default is 600 (0.1 sec per minute).
+    """
+    with open(path) as csvfile:
+        reader = csv.DictReader(csvfile)
+        previous_time = None
+        for row in reader:
+            current_time = datetime.fromisoformat(row["timestamp"])
+            if previous_time is not None:
+                delta_minutes = (current_time - previous_time).total_seconds() / 60
+                time.sleep(delta_minutes / speed)
+            print(row)
+            previous_time = current_time
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Replay a FireSight demo dataset")
+    parser.add_argument("dataset", help="Path to dataset CSV", default="demo_dataset.csv", nargs="?")
+    parser.add_argument("--speed", type=float, default=600.0, help="Dataset minutes per real second")
+    args = parser.parse_args()
+    replay_dataset(args.dataset, args.speed)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add scripts directory with demo dataset generator and replay tool
- document dataset format and usage instructions in README

## Testing
- `python3 scripts/generate_demo_dataset.py demo_dataset.csv`
- `python3 scripts/replay_fire_scenario.py demo_dataset.csv --speed 10000`