### PR TITLE
Add simple FastAPI backend

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+__pycache__/
+*.pyc

--- a/README.md
+++ b/README.md
@@ -1,1 +1,16 @@
-# firesight-prototype
+# FireSight Prototype
+
+This repository contains a basic frontend prototype (`index.html`) and a FastAPI backend used for experimentation.
+
+## Running the API
+
+1. Install dependencies (preferably in a virtual environment):
+   ```bash
+   pip install -r requirements.txt
+   ```
+2. Start the development server:
+   ```bash
+   uvicorn api.main:app --reload
+   ```
+
+The API provides automatic Swagger documentation at `http://localhost:8000/docs`.

--- a/api/main.py
+++ b/api/main.py
@@ -1,0 +1,56 @@
+from typing import List
+from fastapi import FastAPI
+from fastapi.middleware.cors import CORSMiddleware
+from pydantic import BaseModel
+
+app = FastAPI(title="FireSight API", description="Prototype REST API for FireSight")
+
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=["*"],  # In production, specify allowed origins
+    allow_credentials=True,
+    allow_methods=["*"],
+    allow_headers=["*"],
+)
+
+class Alert(BaseModel):
+    id: int
+    message: str
+    time: str
+    status: str
+
+# Mock in-memory data
+aaa_alerts = [
+    {"id": 1, "message": "Fire spotted near park", "time": "2023-01-01T10:00:00", "status": "new"},
+    {"id": 2, "message": "Smoke detected downtown", "time": "2023-01-01T11:00:00", "status": "acknowledged"},
+]
+
+feed_summary = {
+    "summary": "No critical incidents at this time"
+}
+
+class PredictRequest(BaseModel):
+    features: List[float]
+
+class PredictResponse(BaseModel):
+    prediction: float
+
+@app.get("/alerts", response_model=List[Alert])
+def get_alerts() -> List[Alert]:
+    """Return current mock alerts."""
+    return aaa_alerts
+
+@app.get("/data/summary")
+def get_summary() -> dict:
+    """Return latest fused feed summary."""
+    return feed_summary
+
+@app.post("/predict", response_model=PredictResponse)
+def predict(req: PredictRequest) -> PredictResponse:
+    """Return a simple prediction based on the input."""
+    pred_value = sum(req.features)
+    return PredictResponse(prediction=pred_value)
+
+if __name__ == "__main__":
+    import uvicorn
+    uvicorn.run(app, host="0.0.0.0", port=8000)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+fastapi
+uvicorn
+pydantic


### PR DESCRIPTION
## Summary
- add FastAPI application with `/alerts`, `/data/summary`, and `/predict`
- enable CORS and auto Swagger docs
- document how to run the API
- ignore Python cache

## Testing
- `python3 -m py_compile api/main.py`
