### PR TITLE
Add React dashboard demo and clarify README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,44 @@
-# firesight-prototype
+# FireSight Prototype
+
+This repository contains prototype interfaces and demo utilities for the FireSight dashboard.
+
+## Web UI prototypes
+
+Two HTML files illustrate different approaches:
+
+- `index.html` – a static page with a sidebar and alert interactions.
+- `dashboard.html` – a lightweight React demo that displays live alerts, a Leaflet map and a sample Chart.js graph. Open this file directly in a browser; all dependencies load from public CDNs so no build step is required.
+
+## Demo Data Scripts
+
+The `scripts` directory provides helper utilities for demos and testing:
+
+- `generate_demo_dataset.py` creates a 24‑hour CSV file with simulated sensor readings and a noon ignition event.
+- `replay_fire_scenario.py` prints dataset rows to the console in sequence so the scenario can be replayed quickly.
+
+### Dataset format
+
+The generated CSV has the following columns:
+
+| column | description |
+| --- | --- |
+| `timestamp` | ISO‑8601 timestamp for each minute of the day |
+| `temperature_c` | temperature in Celsius |
+| `humidity_pct` | relative humidity percentage |
+| `co2_ppm` | CO₂ concentration in ppm |
+| `smoke` | `0` or `1` to indicate smoke detection |
+| `flame` | `0` or `1` to indicate flame detection |
+
+The ignition event increases temperature and CO₂ while setting both `smoke` and `flame` to `1` for approximately 15 minutes.
+
+To create the dataset run:
+
+```bash
+python3 scripts/generate_demo_dataset.py demo_dataset.csv
+```
+
+Then replay it with:
+
+```bash
+python3 scripts/replay_fire_scenario.py demo_dataset.csv
+```

--- a/dashboard.html
+++ b/dashboard.html
@@ -1,0 +1,74 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>FireSight React Demo</title>
+    <link rel="stylesheet" href="https://unpkg.com/leaflet/dist/leaflet.css" />
+    <script crossorigin src="https://unpkg.com/react@17/umd/react.development.js"></script>
+    <script crossorigin src="https://unpkg.com/react-dom@17/umd/react-dom.development.js"></script>
+    <script src="https://unpkg.com/leaflet/dist/leaflet.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
+    <style>
+        body { margin: 0; font-family: Arial, sans-serif; }
+        #root { height: 100vh; }
+    </style>
+</head>
+<body>
+    <div id="root"></div>
+    <script>
+        const { useEffect, useRef } = React;
+
+        function Dashboard() {
+            const mapRef = useRef(null);
+            useEffect(() => {
+                const map = L.map(mapRef.current).setView([37.7749, -122.4194], 10);
+                L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
+                    attribution: '&copy; OpenStreetMap contributors'
+                }).addTo(map);
+            }, []);
+
+            useEffect(() => {
+                const ctx = document.getElementById('chart').getContext('2d');
+                new Chart(ctx, {
+                    type: 'line',
+                    data: {
+                        labels: ['0', '5', '10', '15'],
+                        datasets: [{
+                            label: 'Prediction',
+                            data: [0, 10, 20, 35],
+                            borderColor: 'red',
+                            fill: false
+                        }]
+                    },
+                    options: { responsive: true, maintainAspectRatio: false }
+                });
+            }, []);
+
+            const alerts = [
+                'Sensor triggered at 12:05',
+                'Flame detected at 12:10'
+            ];
+
+            return (
+                React.createElement('div', { style: { display: 'flex', height: '100%' } },
+                    React.createElement('div', {
+                        style: { width: '25%', padding: '1rem', borderRight: '1px solid #ccc', overflow: 'auto' }
+                    },
+                        React.createElement('h2', null, 'Live Alerts'),
+                        React.createElement('ul', null,
+                            alerts.map((a, i) => React.createElement('li', { key: i }, a))
+                        )
+                    ),
+                    React.createElement('div', { style: { flexGrow: 1, display: 'flex', flexDirection: 'column' } },
+                        React.createElement('div', { ref: mapRef, style: { flexGrow: 1 } }),
+                        React.createElement('canvas', { id: 'chart', style: { height: '200px' } })
+                    )
+                )
+            );
+        }
+
+        ReactDOM.render(React.createElement(Dashboard), document.getElementById('root'));
+    </script>
+</body>
+</html>

--- a/scripts/generate_demo_dataset.py
+++ b/scripts/generate_demo_dataset.py
@@ -1,0 +1,66 @@
+import csv
+import random
+from datetime import datetime, timedelta
+import argparse
+
+
+def generate_dataset(output_path: str, start_time: datetime, minutes: int = 1440):
+    """Generate a simulated multi-sensor dataset with a fire ignition event."""
+    ignition_start = start_time + timedelta(hours=12)
+    ignition_end = ignition_start + timedelta(minutes=15)
+
+    fieldnames = [
+        "timestamp",
+        "temperature_c",
+        "humidity_pct",
+        "co2_ppm",
+        "smoke",
+        "flame"
+    ]
+
+    with open(output_path, "w", newline="") as csvfile:
+        writer = csv.DictWriter(csvfile, fieldnames=fieldnames)
+        writer.writeheader()
+
+        current_time = start_time
+        for _ in range(minutes):
+            row = {
+                "timestamp": current_time.isoformat(),
+                "temperature_c": round(random.uniform(18, 25), 2),
+                "humidity_pct": round(random.uniform(35, 55), 2),
+                "co2_ppm": round(random.uniform(400, 600), 2),
+                "smoke": 0,
+                "flame": 0,
+            }
+
+            if ignition_start <= current_time <= ignition_end:
+                # escalate sensor readings to simulate fire
+                progress = (current_time - ignition_start).total_seconds() / (
+                    ignition_end - ignition_start
+                ).total_seconds()
+                row["temperature_c"] = round(25 + 75 * progress, 2)
+                row["humidity_pct"] = round(30 - 20 * progress, 2)
+                row["co2_ppm"] = round(600 + 500 * progress, 2)
+                row["smoke"] = 1
+                row["flame"] = 1 if progress > 0.3 else 0
+
+            writer.writerow(row)
+            current_time += timedelta(minutes=1)
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Generate a demo FireSight dataset")
+    parser.add_argument(
+        "output",
+        help="Path to output CSV file",
+        default="demo_dataset.csv",
+        nargs="?",
+    )
+    args = parser.parse_args()
+    start = datetime(2025, 5, 11)
+    generate_dataset(args.output, start)
+    print(f"Dataset written to {args.output}")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/replay_fire_scenario.py
+++ b/scripts/replay_fire_scenario.py
@@ -1,0 +1,34 @@
+import csv
+import argparse
+import time
+from datetime import datetime
+
+
+def replay_dataset(path: str, speed: float = 600.0):
+    """Replay dataset rows to stdout at accelerated speed.
+
+    Each row represents a minute. The speed factor represents how many
+    dataset minutes pass per real second. Default is 600 (0.1 sec per minute).
+    """
+    with open(path) as csvfile:
+        reader = csv.DictReader(csvfile)
+        previous_time = None
+        for row in reader:
+            current_time = datetime.fromisoformat(row["timestamp"])
+            if previous_time is not None:
+                delta_minutes = (current_time - previous_time).total_seconds() / 60
+                time.sleep(delta_minutes / speed)
+            print(row)
+            previous_time = current_time
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Replay a FireSight demo dataset")
+    parser.add_argument("dataset", help="Path to dataset CSV", default="demo_dataset.csv", nargs="?")
+    parser.add_argument("--speed", type=float, default=600.0, help="Dataset minutes per real second")
+    args = parser.parse_args()
+    replay_dataset(args.dataset, args.speed)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add `dashboard.html` React prototype with map, alerts, and chart
- document both HTML files and data scripts in README

## Testing
- `python3 scripts/generate_demo_dataset.py demo_dataset.csv`
- `python3 scripts/replay_fire_scenario.py demo_dataset.csv --speed 10000` *(fails with BrokenPipeError after piping to head)*